### PR TITLE
Failing test case - undefined parameter

### DIFF
--- a/test/sample7.coffee
+++ b/test/sample7.coffee
@@ -1,2 +1,9 @@
+#these 2 make bad javascript (undefined/null aren’t functions)
 foo undefined undefined undefined
 foo null null null
+
+foo bar baz undefined
+foo bar baz null
+
+foo undefined, undefined, undefined
+foo null, null, null

--- a/test/sample7.coffee
+++ b/test/sample7.coffee
@@ -1,1 +1,2 @@
 foo undefined undefined undefined
+foo null null null

--- a/test/sample7.coffee
+++ b/test/sample7.coffee
@@ -1,0 +1,1 @@
+foo undefined undefined undefined


### PR DESCRIPTION
There seems to be a bug when the value `undefined` is passed as a parameter.

I’d expect `foo undefined undefined undefined` to be produced, instead I get `fooundefinedundefinedundefined` when running coffee-fmt
