### PR TITLE
Bug: string keys don’t work in objects

### DIFF
--- a/test/object_keys.coffee
+++ b/test/object_keys.coffee
@@ -1,0 +1,4 @@
+{
+  "something": 1
+  "something-else": 2
+}


### PR DESCRIPTION
For this test case, `coffee src/cmd.coffee -i test/object_keys.coffee` produces

```
{
"something"1
"something-else"2
}
```

without colons.
